### PR TITLE
Add support for Bosh links in postgresql and postgresql-extensible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'bosh-template'
+  gem 'rspec'
+  gem 'rspec-collection_matchers'
+  gem 'rspec-its'
+  gem 'toml'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,41 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bosh-template (2.2.0)
+      semi_semantic (~> 1.2.0)
+    diff-lcs (1.3)
+    parslet (1.8.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-collection_matchers (1.1.3)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    semi_semantic (1.2.0)
+    toml (0.2.0)
+      parslet (~> 1.8.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bosh-template
+  rspec
+  rspec-collection_matchers
+  rspec-its
+  toml
+
+BUNDLED WITH
+   1.17.1

--- a/jobs/telegraf-agent/spec
+++ b/jobs/telegraf-agent/spec
@@ -8,6 +8,11 @@ templates:
 packages:
 - telegraf-agent
 
+consumes:
+- name: postgres
+  type: database
+  optional: true
+
 properties:
   global_tags:
     description: |

--- a/jobs/telegraf-agent/templates/telegraf.conf.erb
+++ b/jobs/telegraf-agent/templates/telegraf.conf.erb
@@ -35,24 +35,56 @@
   pid_finder = "<%= p("inputs.procstat.pid_finder") %>"
 <% end %>
 
-<% if_p("inputs.postgresql.address") do |addr| %>
+<%
+    addr = nil
+    if_p("inputs.postgresql.address") { |addr_p| addr = addr_p }
+    unless addr
+      if_link("postgres") do |postgres_link|
+        host_ip = postgres_link.instances[0].address
+        username = postgres_link.p("databases.roles").first["name"]
+        password = postgres_link.p("databases.roles").first["password"]
+        database = postgres_link.p("databases.databases").first["name"]
+        addr = "postgres://#{username}:#{password}@#{host_ip}/#{database}"
+      end
+    end
+%>
+
+<% if addr %>
 [[inputs.postgresql]]
   address = <%= addr.to_json %>
   ignored_databases = <%= p("inputs.postgresql.ignored_databases").to_json %>
   databases = <%= p("inputs.postgresql.databases").to_json %>
 <% end %>
 
-<% if_p("inputs.postgresql_extensible.address") do |addr| %>
+<%
+    queries = false
+    if_p("inputs.postgresql_extensible.queries") { |query_arr| queries = !query_arr.empty? }
+
+    addr = nil
+    if_p("inputs.postgresql_extensible.address") { |addr_p| addr = addr_p }
+    unless addr
+      if_link("postgres") do |postgres_link|
+        host_ip = postgres_link.instances[0].address
+        username = postgres_link.p("databases.roles").first["name"]
+        password = postgres_link.p("databases.roles").first["password"]
+        database = postgres_link.p("databases.databases").first["name"]
+        addr = "postgres://#{username}:#{password}@#{host_ip}/#{database}"
+      end
+    end
+%>
+
+
+<% if addr && queries %>
 [[inputs.postgresql_extensible]]
   address = <%= addr.to_json %>
   databases = <%= p("inputs.postgresql_extensible.databases").to_json %>
   outputaddress = <%= p("inputs.postgresql_extensible.outputaddress").to_json %>
   <% p("inputs.postgresql_extensible.queries").each do |query| %>
   [[inputs.postgresql_extensible.query]]
-    sqlquery=<%= query["query"].to_json %>
-    version=<%= (query["version"] || 0).to_json %>
-    withdbname=<%= (!!query["withdbname"]).to_json %>
-    tagvalue=<%= (query["tags"] || []).join(",").to_json %>
-    measurement=<%= (query["measurement"] || "").to_json %>
+    sqlquery = <%= query["query"].to_json %>
+    version = <%= (query["version"] || 0).to_json %>
+    withdbname = <%= (!!query["withdbname"]).to_json %>
+    tagvalue = <%= (query["tags"] || []).join(",").to_json %>
+    measurement = <%= (query["measurement"] || "").to_json %>
   <% end %>
 <% end %>

--- a/spec/jobs/telegraf-agent/telegraf_conf_spec.rb
+++ b/spec/jobs/telegraf-agent/telegraf_conf_spec.rb
@@ -1,0 +1,184 @@
+require 'rspec'
+require 'rspec/collection_matchers'
+require 'json'
+require 'toml'
+require 'bosh/template/test'
+
+describe 'telegraf-agent job' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
+  let(:job) { release.job('telegraf-agent') }
+
+  describe 'postgresql config' do
+    let(:template) { job.template('config/telegraf.conf') }
+    let(:influx) { { 'url' => 'influx_url', 'database' => 'influx_db' } }
+    let(:postgres_link) do
+      Bosh::Template::Test::Link.new(
+        name: 'postgres',
+        instances: [Bosh::Template::Test::LinkInstance.new(address: 'mock_ip_addr')],
+        properties: {
+          'databases' => {
+            'databases' => [
+              {
+                'name' => 'db_name_one'
+              }
+            ],
+            'roles' => [
+              {
+                'name' => 'role_name_one',
+                'password' => 'role_pw_one'
+              }
+            ],
+            'port' => 123
+          }
+        }
+      )
+    end
+
+    it 'configures influxdb correctly' do
+      rendered = template.render('influxdb' => influx)
+      config = TOML::Parser.new(rendered).parsed
+
+      expect(config['outputs']['influxdb'][0]['urls']).to contain_exactly('influx_url')
+      expect(config['outputs']['influxdb'][0]['database']).to eq('influx_db')
+      expect(config['inputs']).to be_nil
+    end
+
+    it 'configures postgresql correctly' do
+      rendered = template.render(
+        'influxdb' => influx,
+        'inputs' => {
+          'postgresql' => {
+            'address' => 'psql_addr'
+          }
+        }
+      )
+      config = TOML::Parser.new(rendered).parsed
+
+      postgresql_conf = config['inputs']['postgresql']
+      expect(postgresql_conf).to have(1).entries
+      expect(postgresql_conf[0]['address']).to eq('psql_addr')
+      expect(postgresql_conf[0]['databases']).to be_empty
+      expect(postgresql_conf[0]['ignored_databases']).to be_empty
+    end
+
+    it 'configures postgresql correctly when address and link given' do
+      rendered = template.render(
+        {
+          'influxdb' => influx,
+          'inputs' => {
+            'postgresql' => {
+              'address' => 'psql_addr'
+            }
+          }
+        },
+        consumes: [postgres_link]
+      )
+      config = TOML::Parser.new(rendered).parsed
+
+      postgresql_conf = config['inputs']['postgresql']
+      expect(postgresql_conf).to have(1).entries
+      expect(postgresql_conf[0]['address']).to eq('psql_addr')
+      expect(postgresql_conf[0]['databases']).to be_empty
+      expect(postgresql_conf[0]['ignored_databases']).to be_empty
+
+      postgresql_extensible = config['inputs']['postgresql_extensible']
+      expect(postgresql_extensible).to be_nil
+    end
+
+    it 'configures postgresql correctly when only link given' do
+      rendered = template.render(
+        {
+          'influxdb' => influx,
+          'inputs' => {
+            'postgresql' => {
+              'ignored_databases' => [],
+              'databases' => []
+            }
+          }
+        },
+        consumes: [postgres_link]
+      )
+      config = TOML::Parser.new(rendered).parsed
+
+      postgresql_conf = config['inputs']['postgresql']
+      expect(postgresql_conf).to have(1).entries
+      expect(postgresql_conf[0]['address']).to eq('postgres://role_name_one:role_pw_one@mock_ip_addr/db_name_one')
+      expect(postgresql_conf[0]['databases']).to be_empty
+      expect(postgresql_conf[0]['ignored_databases']).to be_empty
+    end
+
+    it 'configures postgresql_extensible correctly given queries' do
+      rendered = template.render(
+        {
+          'influxdb' => influx,
+          'inputs' => {
+            'postgresql_extensible' => {
+              'address' => 'extensible_ip_addr',
+              'databases' => [],
+              'outputaddress' => 'extensible_output_addr',
+              'queries' => [
+                {
+                  'measurement' => 'm1',
+                  'query' => 'q1',
+                  'version' => 1,
+                  'withdbname' => false,
+                  'tags' => []
+                },
+                {
+                  'measurement' => 'm2',
+                  'query' => 'q2',
+                  'version' => 2,
+                  'withdbname' => true,
+                  'tags' => ['q2_tag']
+                }
+              ]
+            }
+          }
+        },
+        consumes: [postgres_link]
+      )
+
+      config = TOML::Parser.new(rendered).parsed
+
+      postgresql_ext_conf = config['inputs']['postgresql_extensible']
+      expect(postgresql_ext_conf).to have(1).entries
+      expect(postgresql_ext_conf[0]['address']).to eq('extensible_ip_addr')
+
+      queries = postgresql_ext_conf[0]['query']
+      expect(queries).to have(2).entries
+
+      expect(queries[0]['measurement']).to eq('m1')
+      expect(queries[0]['sqlquery']).to eq('q1')
+      expect(queries[0]['version']).to eq(1)
+      expect(queries[0]['withdbname']).to eq(false)
+      expect(queries[0]['tagvalue']).to be_empty
+
+      expect(queries[1]['measurement']).to eq('m2')
+      expect(queries[1]['sqlquery']).to eq('q2')
+      expect(queries[1]['version']).to eq(2)
+      expect(queries[1]['withdbname']).to eq(true)
+      expect(queries[1]['tagvalue']).to eq('q2_tag')
+    end
+
+    it 'does not add postgresql_extensible to config if no queries provided' do
+      rendered = template.render(
+        {
+          'influxdb' => influx,
+          'inputs' => {
+            'postgresql_extensible' => {
+              'databases' => [],
+              'outputaddress' => 'extensible_output_addr',
+              'queries' => []
+            }
+          }
+        },
+        consumes: [postgres_link]
+      )
+
+      config = TOML::Parser.new(rendered).parsed
+
+      postgresql_ext_conf = config['inputs']['postgresql_extensible']
+      expect(postgresql_ext_conf).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
If the user does not provide values for the postgres address, the
template will form the address from a postgres Bosh link if one is
available.

This commit assumes that there is only one postgres database link and
will configure both postgresql and postgresql_extensible against this
single database instance.

If the user does not specify both a postgresql-extensible address (or a
link provided) *and* a minimum of one query, the extensible section will
be omitted from the config.

Co-authored-by: Bradford D. Boyle <bboyle@pivotal.io>
Co-authored-by: Trevor Yacovone <tyacovone@pivotal.io>