### PR TITLE
add options to configure disk and net inputs

### DIFF
--- a/jobs/telegraf-agent/spec
+++ b/jobs/telegraf-agent/spec
@@ -150,3 +150,12 @@ properties:
       the native finder performs the search directly in a manor dependent on
       the platform.
     default: native
+
+  inputs.disk.mount_points:
+    description: |
+      The mount points for which disk stats should be collected.
+    default: ["/"]
+
+  inputs.net.interfaces:
+    description: |
+      An array of network interfaces for which stats should be collected.

--- a/jobs/telegraf-agent/templates/telegraf.conf.erb
+++ b/jobs/telegraf-agent/templates/telegraf.conf.erb
@@ -56,3 +56,13 @@
     measurement=<%= (query["measurement"] || "").to_json %>
   <% end %>
 <% end %>
+
+<% if_p("inputs.disk.mount_points") do |mount_points| %>
+[[inputs.disk]]
+  mount_points=<%= mount_points %>
+<% end %>
+
+<% if_p("inputs.net.interfaces") do |ifaces| %>
+[[inputs.net]]
+  interfaces=<%= ifaces %>
+<% end %>


### PR DESCRIPTION
Signed-off-by: Bin Ju <bju@pivotal.io>
Co-authored-by: Divya Dadlani <ddadlani@pivotal.io>

This is to fix https://github.com/pivotal/concourse-ops/issues/95 .  We collect too many dimensions of the `net` and `disk` metrics that we don't use. We'd like to be able to narrow it down for the concourse prod deployment.